### PR TITLE
Fix missing 'using System' in SettingsViewModel

### DIFF
--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Windows;


### PR DESCRIPTION
SettingsViewModel.cs was missing using System;, causing a build error on Action type. Added the missing directive.